### PR TITLE
Remove property all from viteconfig

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,7 +11,6 @@ export default defineConfig({
     coverage: {
       provider: "v8",
       reporter: ["lcov", "text"],
-      all: true,
       include: ["src/**/*.{ts,tsx}"],
       exclude: [
         "**/*.test.{ts,tsx}",


### PR DESCRIPTION
Remove unnecessary `all` property from viteconfig