### PR TITLE
Add arrange to each of the tests

### DIFF
--- a/src/bike/components/BikeForm/BikeForm.tsx
+++ b/src/bike/components/BikeForm/BikeForm.tsx
@@ -47,7 +47,7 @@ const BikeForm = ({ submitBike }: BikeFormProps): React.ReactElement => {
 
           setBikeFormData(bikeFormDataInitialState);
 
-          await navigate("/bicis");
+          navigate("/bicis");
         }}
       >
         <div className="bike-form__form-group">

--- a/src/bike/pages/BikeFormPage/BikeFormPage.test.tsx
+++ b/src/bike/pages/BikeFormPage/BikeFormPage.test.tsx
@@ -37,15 +37,14 @@ describe("Given the BikeFormPage component", () => {
       const bikeFormPageTitle = screen.getByRole("heading", {
         name: bikeFormPageRegExp,
       });
-
       expect(bikeFormPageTitle).toBeInTheDocument();
     });
   });
 
-  describe("When the user fills de form", () => {
-    const user = userEvent.setup();
+  describe("When the use fills the form and the bike is created", () => {
+    test("Then it should show the message: 'Éxito al crear la bici!'", async () => {
+      const user = userEvent.setup();
 
-    const fillAndSubmit = async () => {
       const brand = screen.getByLabelText(/marca/i);
       const model = screen.getByLabelText(/modelo/i);
       const mode = screen.getByLabelText(/disciplina/i);
@@ -60,54 +59,70 @@ describe("Given the BikeFormPage component", () => {
       await user.type(mode, "Carretera");
       await user.type(
         specs,
-        "La Madone SL 6 Disc ofrece un rendimiento aerodinámico avanzado y las sensaciones de nuestra bicicleta de competición definitiva, aunque a un precio más asequible. Incorpora ruedas aerodinámicas, una rótula IsoSpeed que absorbe las irregularidades de la carretera, potentes frenos de disco hidráulico, y una estética que invita a rodar a toda velocidad.",
+        "La Madone SL 6 Disc ofrece un rendimiento aerodinámico.",
       );
       await user.type(material, "Carbon");
       await user.type(wheelSize, "28");
-      await user.type(
-        imageUrl,
-        `https://media.trekbikes.com/image/upload/f_auto,fl_progressive:semi,q_auto,w_1920,h_1440,c_pad/MadoneSL6Disc_20_28714_A_Portrait`,
-      );
+      await user.type(imageUrl, `https://media.trekbikes.com/image/`);
       await user.type(alternativeText, "una bici amarilla y negra");
 
       const submitButton = screen.getByRole("button", { name: /crear/i });
 
       await user.click(submitButton);
-    };
 
-    describe("When the bike is created", () => {
-      test("Then it should show the message: 'Éxito al crear la bici!'", async () => {
-        const expectedMessage = /Éxito al crear la bici/i;
+      const expectedMessage = /Éxito al crear la bici/i;
 
-        await fillAndSubmit();
+      const successMessage = screen.getByText(expectedMessage);
 
-        const successMessage = screen.getByText(expectedMessage);
-
-        expect(successMessage).toBeVisible();
-      }, 10000);
+      expect(successMessage).toBeVisible();
     });
+  });
 
-    describe("When the client throws an error when creating a bike", () => {
-      test("Then it should show the message: 'Ha ocurrido un error al crear la bici'", async () => {
-        server.use(
-          http.post(`${import.meta.env.VITE_API_URL}bikes`, () => {
-            return HttpResponse.json<{ newBike: Bike }>(
-              {
-                newBike: trekBikeMock,
-              },
-              { status: 409 },
-            );
-          }),
-        );
+  describe("When user fills the form with the same properties of an existing bike", () => {
+    test("Then it should show the message: 'Ha ocurrido un error al crear la bici'", async () => {
+      server.use(
+        http.post(`${import.meta.env.VITE_API_URL}bikes`, () => {
+          return HttpResponse.json<{ newBike: Bike }>(
+            {
+              newBike: trekBikeMock,
+            },
+            { status: 409 },
+          );
+        }),
+      );
 
-        const expectedMessage = /Ha ocurrido un error al crear la bici/i;
+      const user = userEvent.setup();
 
-        await fillAndSubmit();
+      const brand = screen.getByLabelText(/marca/i);
+      const model = screen.getByLabelText(/modelo/i);
+      const mode = screen.getByLabelText(/disciplina/i);
+      const specs = screen.getByText(/especificaciones/i);
+      const material = screen.getByLabelText(/material/i);
+      const wheelSize = screen.getByLabelText(/tamaño de rueda/i);
+      const imageUrl = screen.getByLabelText(/URL de la imagen/i);
+      const alternativeText = screen.getByLabelText(/texto alternativo/i);
 
-        const error = screen.getByText(expectedMessage);
+      await user.type(brand, "Trek");
+      await user.type(model, "Madone sl 6");
+      await user.type(mode, "Carretera");
+      await user.type(
+        specs,
+        "La Madone SL 6 Disc ofrece un rendimiento aerodinámico.",
+      );
+      await user.type(material, "Carbon");
+      await user.type(wheelSize, "28");
+      await user.type(imageUrl, `https://media.trekbikes.com/image/`);
+      await user.type(alternativeText, "una bici amarilla y negra");
 
-        expect(error).toBeVisible();
-      }, 10000);
+      const submitButton = screen.getByRole("button", { name: /crear/i });
+
+      await user.click(submitButton);
+
+      const expectedMessage = /Ha ocurrido un error al crear la bici/i;
+
+      const error = screen.getByText(expectedMessage);
+
+      expect(error).toBeVisible();
     });
   });
 });


### PR DESCRIPTION
Add arrange to each tests in order to test each toast (possitive and negative use case feedback) 
Adjust the amount of text entered in the form to be able to test asynchronous processes without timeout